### PR TITLE
Support for jq highlighting

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,10 @@
     "grammars": [{
       "language": "fabric",
       "scopeName": "source.hcl.fabric",
-      "path": "./syntaxes/fabric.tmLanguage.json"
+      "path": "./syntaxes/fabric.tmLanguage.json",
+      "embeddedLanguages": {
+        "fenced_code.block.language.jq": "jq"
+      }
     }]
   }
 }

--- a/syntaxes/fabric.tmLanguage.json
+++ b/syntaxes/fabric.tmLanguage.json
@@ -48,6 +48,59 @@
         }
       }
     },
+    "query_jq_call": {
+      "begin": "(query_jq)\\s*(\\()",
+      "beginCaptures": {
+        "1": {
+          "name": "support.function.builtin.fabric"
+        },
+        "2": {
+          "name": "punctuation.section.parens.begin.fabric"
+        }
+      },
+      "comment": "Query jq call",
+      "patterns": [
+        {
+          "include": "#jq_heredoc"
+        },
+        {
+          "include": "#comments"
+        },
+        {
+          "include": "#expressions"
+        }
+      ],
+      "end": "(\\))",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.section.parens.end.fabric"
+        }
+      }
+    },
+    "jq_heredoc": {
+      "begin": "(\\<\\<\\-?)\\s*(\\w+)\\s*",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.operator.heredoc.fabric"
+        },
+        "2": {
+          "name": "keyword.control.heredoc.fabric"
+        }
+      },
+      "comment": "Jq Heredoc string",
+      "contentName": "fenced_code.block.language.jq",
+      "patterns": [
+        {
+          "include": "source.jq"
+        }
+      ],
+      "end": "(\\2)",
+      "endCaptures": {
+        "1": {
+          "name": "keyword.control.heredoc.fabric"
+        }
+      }
+    },
     "attribute_definition": {
       "captures": {
         "1": {
@@ -228,6 +281,9 @@
         },
         {
           "include": "#attribute_access"
+        },
+        {
+          "include": "#query_jq_call"
         },
         {
           "include": "#functions"


### PR DESCRIPTION
Adds support for jq queries to be highlighted within heredoc strings passed to query_jq function. 

Requires separate jq highlighter [like this one](https://marketplace.visualstudio.com/items?itemName=jq-syntax-highlighting.jq-syntax-highlighting) 

![Screenshot 2024-06-12 at 00 25 15](https://github.com/blackstork-io/vscode-fabric/assets/16529201/48c3615f-52f5-4183-98fe-7addfc65ee45)

`query` attributes are not highlighted (since they are on their way out). Regular strings are not highlighted, since they could contain escaped quotes that would be unexpected by the jq highlighter.